### PR TITLE
Fix expire_all_in_set-method and back it with a test.

### DIFF
--- a/redis_cache/rediscache.py
+++ b/redis_cache/rediscache.py
@@ -130,11 +130,11 @@ class SimpleCache(object):
         :return: int, int
         """
         all_members = self.keys()
-        
+
         pipe = self.connection.pipeline()
         for member in all_members:
-            pipe.expire("{0}:{1}".format(self.prefix, member), 0)
-        expired = len(filter(pipe.execute()))
+            pipe.expire(self.make_key(member), 0)
+        expired = len(filter(None, pipe.execute()))
         return len(self), expired
 
     def isexpired(self, key):

--- a/redis_cache/test_rediscache.py
+++ b/redis_cache/test_rediscache.py
@@ -120,6 +120,15 @@ class SimpleCacheTest(TestCase):
         self.assertEqual(len(c2), 1)
         c2.flush()
 
+    def test_expire_all_in_set(self):
+        self.c.store("foo", "bir")
+        self.c.store("fuu", "bor")
+        self.c.store("fii", "bur")
+        self.assertEqual(self.c.expire_all_in_set(), (3,3))
+        self.assertTrue(self.c.isexpired("foo"))
+        self.assertTrue(self.c.isexpired("fuu"))
+        self.assertTrue(self.c.isexpired("fii"))
+
     def tearDown(self):
         self.c.flush()
 


### PR DESCRIPTION
Hello,

I was trying to use the expire_all_in_set-method, but got the following TypeError (both in Python 2.7.6 and 3.2.5):

```
TypeError: filter expected 2 arguments, got 1
```

I took a look at the code and propose the following changes to fix this method. I did also include a test to verify the correct functionality.

Best regards ~
