### PR TITLE
Fix connection to use specified db number

### DIFF
--- a/redis_cache/rediscache.py
+++ b/redis_cache/rediscache.py
@@ -81,7 +81,7 @@ class SimpleCache(object):
         try:
             self.connection = RedisConnect(host=self.host,
                                            port=self.port,
-                                           db=0,
+                                           db=self.db,
                                            password=password).connect()
         except RedisNoConnException, e:
             self.connection = None


### PR DESCRIPTION
Cache always uses db0 instead of specified db number. This commit should fix that.
