### PR TITLE
Test and fix unicode-support in key-related functions

### DIFF
--- a/redis_cache/rediscache.py
+++ b/redis_cache/rediscache.py
@@ -83,10 +83,10 @@ class SimpleCache(object):
         self.hashkeys = hashkeys
 
     def make_key(self, key):
-        return "SimpleCache-{0}:{1}".format(self.prefix, key)
+        return u"SimpleCache-{0}:{1}".format(self.prefix, key)
 
     def get_set_name(self):
-        return "SimpleCache-{0}-keys".format(self.prefix)
+        return u"SimpleCache-{0}-keys".format(self.prefix)
 
     def store(self, key, value, expire=None):
         """
@@ -135,13 +135,13 @@ class SimpleCache(object):
         :param key: key being looked-up in Redis
         :return: bool (True) if expired, or int representing current time-to-live (ttl) value
         """
-        ttl = self.connection.pttl("SimpleCache-{0}".format(key))
+        ttl = self.connection.pttl(u"SimpleCache-{0}".format(key))
         if ttl == -1:
             return True
         if not ttl is None:
             return ttl
         else:
-            return self.connection.pttl("{0}:{1}".format(self.prefix, key))
+            return self.connection.pttl(u"{0}:{1}".format(self.prefix, key))
 
     def store_json(self, key, value):
         self.store(key, json.dumps(value))

--- a/redis_cache/test_rediscache.py
+++ b/redis_cache/test_rediscache.py
@@ -1,3 +1,5 @@
+#-*- coding: utf-8 -*-
+#
 #SimpleCache Tests
 #~~~~~~~~~~~~~~~~~~~
 from rediscache import SimpleCache, cache_it, cache_it_json, CacheMissException, ExpiredKeyException
@@ -173,7 +175,7 @@ class SimpleCacheTest(TestCase):
         d = self.c.mget_json(["json_a1", "json_a2"])
         self.assertEqual(d["json_a1"], payload_a1)
         self.assertEqual(d["json_a2"], payload_a2)
-        
+
     def test_mget_json_nonexistant_key(self):
         payload_b1 = {"example_b1": "data_b1"}
         payload_b3 = {"example_b3": "data_b3"}
@@ -183,6 +185,26 @@ class SimpleCacheTest(TestCase):
         self.assertEqual(d["json_b1"], payload_b1)
         self.assertTrue("json_b2" not in d)
         self.assertEqual(d["json_b3"], payload_b3)
+
+    def test_utf8_key_support(self):
+        error = "{0} raised unexpected {1}"
+        c = SimpleCache(namespace=u"ÄÖÜÀÁßäöüàá")
+        ustr = u"ÄÖÜÀÁßäöüàá"
+
+        try:
+            c.make_key(ustr)
+        except UnicodeEncodeError as e:
+            self.fail(error.format("make_key", e.__class__.__name__))
+
+        try:
+            c.get_set_name()
+        except UnicodeEncodeError as e:
+            self.fail(error.format("get_set_name", e.__class__.__name__))
+
+        try:
+            c.isexpired(ustr)
+        except UnicodeEncodeError as e:
+            self.fail(error.format("isexpired", e.__class__.__name__))
 
     def tearDown(self):
         self.c.flush()


### PR DESCRIPTION
Hello,

I recently came across a problem where I was unable to store keys that had accents or umlaut-characters in them, no matter if I provided unicode or utf8-encoded strings.
After some debugging on my side I realized the problem was actually coming from the key handiling in redis-simple-cache itself. So far, keys were just concatenated to the prefix-string. As the keys are converted to unicode in store(), they are encoded using the ascii-codec while being concatenated and as ascii can't handle the accents and umlauts, this fails. To fix this, one merely has to declare the prefix-bits unicode strings.

I wrote a test that should fail if you leave out the changes in rediscache.py and passes with them.

There might be some more places where the same issue might occur, e.g. in **iter** and the cache_it-decorator, but I can't currently produce a concise testcase for that.
