### PR TITLE
Use pipe.set() in store() when expire is None

### DIFF
--- a/redis_cache/rediscache.py
+++ b/redis_cache/rediscache.py
@@ -126,7 +126,7 @@ class SimpleCache(object):
         if expire is None:
             expire = self.expire
 
-        if isinstance(expire, int) and expire <= 0:
+        if (isinstance(expire, int) and expire <= 0) or (expire == None):
             pipe.set(self.make_key(key), value)
         else:
             pipe.setex(self.make_key(key), expire, value)

--- a/redis_cache/rediscache.py
+++ b/redis_cache/rediscache.py
@@ -126,7 +126,7 @@ class SimpleCache(object):
         if expire is None:
             expire = self.expire
 
-        if (isinstance(expire, int) and expire <= 0) or (expire == None):
+        if (isinstance(expire, int) and expire <= 0) or (expire is None):
             pipe.set(self.make_key(key), value)
         else:
             pipe.setex(self.make_key(key), expire, value)


### PR DESCRIPTION
The documentation specifies (None) for no expiration, but the code checks for any negative number.
The [documentation for setex](https://github.com/andymccurdy/redis-py/blob/master/redis/client.py#L1082) requires the `time` argument to be `an integer or a Python timedelta object`.

**Cause**: Regression introduced by https://github.com/vivekn/redis-simple-cache/commit/1b86ab6bcbc299caba1210d57635329144588538 removing the changes introduced in https://github.com/vivekn/redis-simple-cache/commit/20bb4905d5dcc54dec5c8b8237f048d858dc816b.

**Error**: `redis.exceptions.ResponseError: value is not an integer or out of range`
**Trace**: `File "/usr/local/lib/python2.7/site-packages/redis_cache/rediscache.py", line 139, in store
    pipe.execute()`
**Fix**: Check for expire to be None in addition to the preexisting condition.

**Tests**: Pending PR review...

**Full trace**:

``` bash
  File "/usr/local/lib/python2.7/site-packages/redis_cache/rediscache.py", line 363, in func
    storer(cache_key, result, expire)
  File "/usr/local/lib/python2.7/site-packages/redis_cache/rediscache.py", line 199, in store_json
    self.store(key, json.dumps(value), expire)
  File "/usr/local/lib/python2.7/site-packages/redis_cache/rediscache.py", line 139, in store
    pipe.execute()
  File "/usr/local/lib/python2.7/site-packages/redis/client.py", line 1801, in execute
    return execute(conn, stack, raise_on_error)
  File "/usr/local/lib/python2.7/site-packages/redis/client.py", line 1732, in _execute_transaction
    self.raise_first_error(response)
  File "/usr/local/lib/python2.7/site-packages/redis/client.py", line 1760, in raise_first_error
    raise r
redis.exceptions.ResponseError: value is not an integer or out of range
```
