### PR TITLE
use namespace in cache_it_json and avoid exception when invalidating a namespace

### DIFF
--- a/redis_cache/rediscache.py
+++ b/redis_cache/rediscache.py
@@ -376,7 +376,7 @@ def cache_it_json(limit=10000, expire=DEFAULT_EXPIRY, cache=None, namespace=None
     :return: decorated function
     """
     return cache_it(limit=limit, expire=expire, use_json=True,
-                    cache=cache, namespace=None)
+                    cache=cache, namespace=namespace)
 
 
 def to_unicode(obj, encoding='utf-8'):

--- a/redis_cache/rediscache.py
+++ b/redis_cache/rediscache.py
@@ -172,8 +172,7 @@ class SimpleCache(object):
             with self.connection.pipeline() as pipe:
                 pipe.delete(*all_members)
                 pipe.execute()
-
-        return len(self), len(all_members)
+            return len(self), len(all_members)
 
     def isexpired(self, key):
         """

--- a/redis_cache/rediscache.py
+++ b/redis_cache/rediscache.py
@@ -168,9 +168,10 @@ class SimpleCache(object):
         """
         namespace = self.namespace_key(namespace)
         all_members = list(self.connection.keys(namespace))
-        with self.connection.pipeline() as pipe:
-            pipe.delete(*all_members)
-            pipe.execute()
+        if all_members:
+            with self.connection.pipeline() as pipe:
+                pipe.delete(*all_members)
+                pipe.execute()
 
         return len(self), len(all_members)
 


### PR DESCRIPTION
Just a couple of easy fixes for this really useful library
